### PR TITLE
added compatibility to simulate impinj xArray R680

### DIFF
--- a/llrp.go
+++ b/llrp.go
@@ -10,14 +10,28 @@ import (
 	"encoding/binary"
 )
 
-// LLRP header values
+// LLRP header values, the header is composed of 2 bytes where the first
+// is set to 0x40 or 1024, so 1025 would be 0x0401
 const (
-	ROAccessReportHeader          = 1085
-	ReaderEventNotificationHeader = 1087
-	SetReaderConfigHeader         = 1027
-	SetReaderConfigResponseHeader = 1037
-	KeepaliveHeader               = 1086
-	KeepaliveAckHeader            = 1096
+	ROAccessReportHeader              = 1085 // type 61
+	ReaderEventNotificationHeader     = 1087 // type 63
+	SetReaderConfigHeader             = 1027 // type 3
+	SetReaderConfigResponseHeader     = 1037 // type 13
+	KeepaliveHeader                   = 1086 // type 62
+	KeepaliveAckHeader                = 1096 // type 72
+	GetReaderCapabilityHeader         = 1025 // type 1
+	GetReaderCapabilityResponseHeader = 1035 // type 11
+	GetReaderConfigHeader             = 1026 // type 2
+	GetReaderConfigResponseHeader     = 1036 // type 12
+	DeleteAccessSpecHeader            = 1065 // type 41
+	DeleteAccessSpecResponseHeader    = 1075 // type 51
+	DeleteRospecHeader                = 1045 // type 21
+	DeleteRospecResponseHeader        = 1055 // type 31
+	AddRospecHeader                   = 1044 // type 20
+	AddRospecResponseHeader           = 1054 // type 30
+	EnableRospecHeader                = 1048 // type 24
+	EnableRospecResponseHeader        = 1058 // type 34
+	ImpinjEnableCutomMessageHeader    = 2047 // type 1023
 )
 
 // Pack the data into (partial) LLRP packet payload.

--- a/message.go
+++ b/message.go
@@ -28,7 +28,7 @@ func ReaderEventNotification(messageID uint32, currentTime uint64) []byte {
 	var data = []interface{}{
 		uint16(ReaderEventNotificationHeader), // Rsvd+Ver+Type=63 (READER_EVENT_NOTIFICATION)
 		uint32(readerEventNotificationLength), // Length
-		messageID,                             // ID
+		messageID, // ID
 		readerEventNotificationData,
 	}
 	return Pack(data)
@@ -57,8 +57,170 @@ func SetReaderConfigResponse(messageID uint32) []byte {
 	var data = []interface{}{
 		uint16(SetReaderConfigResponseHeader), // Rsvd+Ver+Type=13 (SET_READER_CONFIG_RESPONSE)
 		uint32(setReaderConfigResponseLength), // Length
-		messageID,                             // ID
+		messageID, // ID
 		llrpStatus,
+	}
+	return Pack(data)
+}
+
+//GetReaderCapability :
+func GetReaderCapability(messageID uint32) []byte {
+	getReaderCapabilityLength := 1 + 10
+	var data = []interface{}{
+		uint16(GetReaderCapabilityHeader),
+		uint32(getReaderCapabilityLength),
+		messageID,
+		uint8(0), //all capabilities
+	}
+	return Pack(data)
+}
+
+//GetReaderCapabilityResponse :
+func GetReaderCapabilityResponse(messageID uint32) []byte {
+
+	llrpStatus := Status()
+	generalCapabilites := GeneralDeviceCapabilities()
+	llrpCapabilities := LlrpCapabilities()
+	c1g2llrpCapabilities := C1G2llrpCapabilities()
+	reguCapabilitles := ReguCapabilities()
+	length := 2 + 4 + 4 + len(llrpStatus) + len(generalCapabilites) + len(llrpCapabilities) + len(reguCapabilitles) + len(c1g2llrpCapabilities)
+	var data = []interface{}{
+		uint16(GetReaderCapabilityResponseHeader),
+		uint32(length),
+		uint32(messageID),
+		llrpStatus,
+		generalCapabilites,
+		llrpCapabilities,
+		reguCapabilitles,
+		// uint8(0),
+		// uint8(0),
+		// uint8(0),
+		c1g2llrpCapabilities,
+	}
+	return Pack(data)
+}
+
+//GetReaderConfigResponse :
+func GetReaderConfigResponse(messageID uint32) []byte {
+	llrpStatus := Status()
+	//numOfAntennas := 52
+	identification := GetReaderConfigResponseIdentification()
+	length := 2 + 4 + 4 + len(llrpStatus) + len(identification) //+ numOfAntennas*9 + numOfAntennas*36
+	var data = []interface{}{
+		uint16(GetReaderConfigResponseHeader),
+		uint32(length),
+		messageID,
+		llrpStatus,
+		identification,
+	}
+	// x := Pack(data)
+	// for i := 1; i <= numOfAntennas; i++ {
+	// 	x = append(x, AntennaProperties(uint16(i))...)
+	// }
+	// for i := 1; i <= numOfAntennas; i++ {
+	// 	x = append(x, AntennaConfiguration(uint16(i))...)
+	// }
+	return Pack(data)
+}
+
+//DeleteAccessSpecResponse : Delete Access Spec Response
+func DeleteAccessSpecResponse(messageID uint32) []byte {
+	llrpStatus := Status()
+	var data = []interface{}{
+		uint16(DeleteAccessSpecResponseHeader),
+		uint32(18), //length
+		messageID,
+		llrpStatus,
+	}
+	return Pack(data)
+}
+
+//DeleteRospecResponse : Delete RoSpec Response
+func DeleteRospecResponse(messageID uint32) []byte {
+	llrpStatus := Status()
+	var data = []interface{}{
+		uint16(DeleteRospecResponseHeader),
+		uint32(18), //length
+		messageID,
+		llrpStatus,
+	}
+	return Pack(data)
+}
+
+//AddRospecResponse : Add ROSpec Response
+func AddRospecResponse(messageID uint32) []byte {
+	llrpStatus := Status()
+	var data = []interface{}{
+		uint16(AddRospecResponseHeader),
+		uint32(18), //length
+		messageID,
+		llrpStatus,
+	}
+	return Pack(data)
+}
+
+//EnableRospecResponse : Enabled Rospec Response
+func EnableRospecResponse(messageID uint32) []byte {
+	llrpStatus := Status()
+	var data = []interface{}{
+		uint16(EnableRospecResponseHeader),
+		uint32(18), //length
+		messageID,
+		llrpStatus,
+	}
+	return Pack(data)
+}
+
+//ReceiveSensitivityEntries : Generates ReceiveSensitivityEntries used in General capabilities
+func ReceiveSensitivityEntries(numOfAntennas int) []interface{} {
+	var data = []interface{}{}
+	for i := 1; i <= numOfAntennas; i++ {
+		x := ReceiveSensitivityEntry(uint16(i))
+		data = append(data, x)
+	}
+	return data
+}
+
+//ReceiveSensitivityEntry :
+func ReceiveSensitivityEntry(id uint16) []byte {
+	var data = []interface{}{
+		uint16(139), //type
+		uint16(8),   //length
+		uint16(id),  //id
+		uint16(11),  //receive sentitvitiy value
+	}
+	return Pack(data)
+}
+
+//GPIOCapabilities : Generates GPIO capabilities proeprty
+func GPIOCapabilities() []byte {
+	var data = []interface{}{
+		uint16(141), //type
+		uint16(8),   //length
+		uint16(0),   //num of GPI port
+		uint16(0),   //num of GPO port
+	}
+	return Pack(data)
+}
+
+//AntennaAirPortList :
+func AntennaAirPortList(numOfAntennas int) []interface{} {
+	var data = []interface{}{}
+	for i := 1; i <= numOfAntennas; i++ {
+		x := AntennaAirPort(uint16(i))
+		data = append(data, x)
+	}
+	return data
+}
+
+//AntennaAirPort :
+func AntennaAirPort(id uint16) []byte {
+	var data = []interface{}{
+		uint16(140), //type
+		uint16(9),   //length
+		uint16(id),
+		uint16(1), //num of protocols
+		uint8(1),  //protocol id : EPCGlobal Class 1 Gen 2
 	}
 	return Pack(data)
 }

--- a/parameter.go
+++ b/parameter.go
@@ -1,5 +1,7 @@
 package llrp
 
+import "time"
+
 // C1G2PC generates C1G2PC parameter from hexpc string.
 func C1G2PC(pc uint16) []byte {
 	var data = []interface{}{
@@ -47,6 +49,37 @@ func EPCData(length uint16, epcLengthBits uint16, epc []byte) []byte {
 			uint16(epcLengthBits), // EPCLengthBits
 			epc, // EPCData string
 		}
+	}
+	return Pack(data)
+}
+
+//ChannelIndex : Generates channelIndex for EPC tag
+func ChannelIndex() []byte {
+	var data = []interface{}{
+		uint8(0x87), //type
+		uint16(11),  //ch index
+	}
+	return Pack(data)
+}
+
+//LastSeenTimestampUTC : Returns the a UNIX timestamp in microseconds
+func LastSeenTimestampUTC() []byte {
+	var data = []interface{}{
+		uint8(0x84),             //type
+		uint64(makeTimestamp()), //timestamp
+	}
+	return Pack(data)
+}
+
+func makeTimestamp() int64 {
+	return time.Now().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+}
+
+//TagSeenCount :
+func TagSeenCount() []byte {
+	var data = []interface{}{
+		uint8(0x88), //type
+		uint16(1),   //tag seen count
 	}
 	return Pack(data)
 }
@@ -118,6 +151,282 @@ func UTCTimeStamp(currentTime uint64) []byte {
 		uint16(128), // Rsvd+Type=128
 		uint16(12),  // Length
 		currentTime, // Microseconds
+	}
+	return Pack(data)
+}
+
+//GeneralDeviceCapabilities : Generates General Device Capabilities
+func GeneralDeviceCapabilities() []byte {
+	numOfAntennas := 52
+	//totalReceiveSensitivities := 42
+	length := 28 // 28 + totalReceiveSensitivities*8 + 8 + numOfAntennas*9
+	var data = []interface{}{
+		uint16(137),           //Type 137
+		uint16(length),        //Length
+		uint16(numOfAntennas), //Max Antenna
+		uint16(16384),         //UTC clock support
+		uint32(25882),         //Manufacturer
+		uint32(2001007),       //Model
+		uint32(0x000a352e),
+		uint32(0x31342e30),
+		uint32(0x2e323430),
+	}
+	x := Pack(data)
+
+	// for i := 1; i <= totalReceiveSensitivities; i++ {
+	// 	x = append(x, ReceiveSensitivityEntry(uint16(i))...)
+	// }
+	// x = append(x, GPIOCapabilities()...)
+	// for i := 1; i <= numOfAntennas; i++ {
+	// 	x = append(x, ReceiveSensitivityEntry(uint16(i))...)
+	// }
+
+	return x
+}
+
+//LlrpCapabilities : generates LLRP_CAPABILITIES
+func LlrpCapabilities() []byte {
+	var data = []interface{}{
+		uint16(142),  //type 142
+		uint16(28),   //length
+		uint8(72),    //rf survery = no, buffer fille warning = yes, client request opspec = no, tag inventory = no, supoprt event = yes
+		uint8(1),     // max priotity level supported
+		uint16(0),    //client request opsec timeout
+		uint32(1),    // max num of rospec
+		uint32(32),   //max num of spec per rospec
+		uint32(1),    //max num of inventory spec per AIspec
+		uint32(1508), //max num of accessSpec
+		uint32(8),    //max num of opspec per AccessSpec
+	}
+	return Pack(data)
+}
+
+//ReguCapabilities : generates Regulatory Capabilities
+func ReguCapabilities() []byte {
+	var data = []interface{}{
+		uint16(143),      //type 143
+		uint16(1189 + 8), //length
+		uint16(840),      // country code
+		uint16(1),        //comm standards, fcc part 15
+		UHFCapabilities(52),
+	}
+	return Pack(data)
+}
+
+//C1G2llrpCapabilities : Generates C1G2llrpCapabilities
+func C1G2llrpCapabilities() []byte {
+	var data = []interface{}{
+		uint16(327), //type 327
+		uint16(7),   //length
+		uint8(64),   //some params
+		uint16(2),   //max num of selectec filter per query
+	}
+	return Pack(data)
+}
+
+//GetReaderConfigResponseIdentification : Generate Identification
+func GetReaderConfigResponseIdentification() []byte {
+	var data = []interface{}{
+		uint16(218),        //type
+		uint16(17),         //length
+		uint8(0),           //id type
+		uint16(0),          //byte count
+		uint32(0x00080016), //Reader ID
+		uint32(0x25ffff11),
+		uint16(0xc167),
+	}
+	return Pack(data)
+}
+
+//AntennaProperties :
+func AntennaProperties(id uint16) []byte {
+	var data = []interface{}{
+		uint16(221), //type
+		uint16(9),   //length
+		uint16(128), //antenna connected
+		uint16(id),
+		uint16(0), //gain
+	}
+	return Pack(data)
+}
+
+func AntennaConfiguration(id uint16) []byte {
+	length := 6 + 6 + 10 + 24 //36
+	var data = []interface{}{
+		uint16(222), //type
+		uint16(length),
+		uint16(id),
+	}
+	x := Pack(data)
+	x = append(x, RFReceiver()...)
+	x = append(x, RFTransmitter()...)
+	x = append(x, C1G2InventoryCommand()...)
+	return x
+}
+
+func RFReceiver() []byte {
+	length := 6
+	var data = []interface{}{
+		uint16(223), //type
+		uint16(length),
+		uint16(1), //reciver sensitivity
+	}
+	return Pack(data)
+}
+
+func RFTransmitter() []byte {
+	length := 10
+	var data = []interface{}{
+		uint16(224), //type
+		uint16(length),
+		uint16(1),  //hop id
+		uint16(0),  //ch index
+		uint16(81), //tx power
+	}
+	return Pack(data)
+}
+
+func C1G2InventoryCommand() []byte {
+	length := 5 + 8 + 11
+	var data = []interface{}{
+		uint16(330), //type
+		uint16(length),
+		uint8(0), //Tag inv state aware
+
+	}
+	x := Pack(data)
+	x = append(x, C1G2RFControl()...)
+	x = append(x, C1G2SingulationControl()...)
+	return x
+}
+
+func C1G2RFControl() []byte {
+	length := 8
+	var data = []interface{}{
+		uint16(335), //type
+		uint16(length),
+		uint16(1000), //mode index
+		uint16(0),    //tari
+	}
+	return Pack(data)
+}
+
+func C1G2SingulationControl() []byte {
+	length := 11
+	var data = []interface{}{
+		uint16(336), //type
+		uint16(length),
+		uint8(0x40), //session 1
+		uint16(32),  //tag pop
+		uint32(0),   //tag transit time
+	}
+	return Pack(data)
+}
+
+// UHFCapabilities :
+func UHFCapabilities(numOfAntennas int) []byte {
+	numOfPowerLevel := 81
+	length := 1189 //numOfPowerLevel*8 + 213 + 324 + 4 //transmitpowerlevel + freqinfo + c1g2 + type + length
+	var data = []interface{}{
+		uint16(144),    //type
+		uint16(length), //length
+	}
+	x := Pack(data)
+
+	for i := 1; i <= numOfPowerLevel; i++ {
+		x = append(x, TransmitPowerLevelEntry(uint16(i), uint16(1000+25*(i-1)))...)
+	}
+	x = append(x, FrequencyInformation()...)
+	x = append(x, C1G2UHFModeRFTable()...)
+	return x
+}
+
+//TransmitPowerLevelEntry :
+func TransmitPowerLevelEntry(id uint16, powerLevel uint16) []byte {
+	var data = []interface{}{
+		uint16(145),        //type
+		uint16(8),          //length
+		uint16(id),         //id
+		uint16(powerLevel), //power value
+	}
+	return Pack(data)
+}
+
+//FrequencyInformation :
+func FrequencyInformation() []byte {
+	length := 213 //2 + 2 + 1 + 208
+	var data = []interface{}{
+		uint16(146),    //type
+		uint16(length), //length
+		uint8(1),       //hopping
+	}
+	x := Pack(data)
+	x = append(x, FrequencyHopTable()...)
+	return x
+}
+
+//FrequencyHopTable :
+func FrequencyHopTable() []byte {
+	numOfHops := 50
+	length := 208 //2 + 2 + 1 + 1 + 2 + numOfHops*4
+	var data = []interface{}{
+		uint16(147),       //type
+		uint16(length),    //length
+		uint8(1),          // hop table id
+		uint8(0),          // reserved
+		uint16(numOfHops), //num of hops
+	}
+	x := Pack(data)
+	for i := 0; i < numOfHops; i++ {
+		x = append(x, frequency(903250+i)...) //some random frequencies\
+	}
+	return x
+}
+
+func frequency(frequency int) []byte {
+	var data = []interface{}{
+		uint32(frequency),
+	}
+	return Pack(data)
+}
+
+//C1G2UHFModeRFTable :
+func C1G2UHFModeRFTable() []byte {
+
+	length := 324 //2 + 2 + 32*10
+	var data = []interface{}{
+		uint16(328),    //type
+		uint16(length), //length
+	}
+	x := Pack(data)
+	x = append(x, C1G2UHFModeRFTableEntry(0)...)
+	x = append(x, C1G2UHFModeRFTableEntry(1)...)
+	x = append(x, C1G2UHFModeRFTableEntry(2)...)
+	x = append(x, C1G2UHFModeRFTableEntry(3)...)
+	x = append(x, C1G2UHFModeRFTableEntry(4)...)
+	x = append(x, C1G2UHFModeRFTableEntry(1000)...)
+	x = append(x, C1G2UHFModeRFTableEntry(1001)...)
+	x = append(x, C1G2UHFModeRFTableEntry(1002)...)
+	x = append(x, C1G2UHFModeRFTableEntry(1003)...)
+	x = append(x, C1G2UHFModeRFTableEntry(1004)...)
+	return x
+}
+
+//C1G2UHFModeRFTableEntry :
+func C1G2UHFModeRFTableEntry(mode int) []byte {
+	var data = []interface{}{
+		uint16(329),    //type
+		uint16(32),     //length
+		uint32(mode),   //mode identifier
+		uint8(80),      //dr : yes , EPC HAG T&C confromance : no
+		uint8(0),       //m : 0
+		uint8(2),       // forward link mod
+		uint8(2),       //speectral mask indicator
+		uint32(640000), // bdr
+		uint32(1500),   //PIE
+		uint32(6250),   //max tari
+		uint32(6250),   //min tari
+		uint32(0),      //tari step
 	}
 	return Pack(data)
 }

--- a/tag_report_data.go
+++ b/tag_report_data.go
@@ -19,17 +19,21 @@ func NewTagReportDataParam(tag *Tag) []byte {
 	epcLengthBits := len(tag.EPC) * 8 // # bytes * 8 = # bits
 	length := 4 + 2 + len(tag.EPC)    // header + epcLengthBits + epc
 	epcd := EPCData(uint16(length), uint16(epcLengthBits), tag.EPC)
-
+	chIndex := ChannelIndex()
+	timestamp := LastSeenTimestampUTC()
+	tagSeenCount := TagSeenCount()
 	// AirProtocolTagData
-	aptd := C1G2PC(tag.PCBits)
+	//aptd := C1G2PC(tag.PCBits)
 
-	tagReportDataLength := len(epcd) + len(aptd) + 4 // Rsvd+Type+length->32bits=4bytes
+	tagReportDataLength := 4 + len(epcd) + len(chIndex) + len(timestamp) + len(tagSeenCount) // Rsvd+Type+length->32bits=4bytes
 
 	// Pack in []byte
 	return Pack([]interface{}{
 		uint16(240),                 // Rsvd+Type=240 (TagReportData parameter)
 		uint16(tagReportDataLength), // Length
 		epcd,
-		aptd,
+		chIndex,
+		timestamp,
+		tagSeenCount,
 	})
 }


### PR DESCRIPTION
I used Wireshark to trace the LLRP protocol while testing with a Impinj xArray R680. From that and the llrp documentation, I was able to find the new message types needed in order to simulate the antenna using the golemu library 