### PR TITLE
changed tag timestamp to microsecond

### DIFF
--- a/llrp.go
+++ b/llrp.go
@@ -13,24 +13,25 @@ import (
 // LLRP header values, the header is composed of 2 bytes where the first
 // is set to 0x40 or 1024, so 1025 would be 0x0401
 const (
-	ROAccessReportHeader              = 1085 // type 61
-	ReaderEventNotificationHeader     = 1087 // type 63
-	SetReaderConfigHeader             = 1027 // type 3
-	SetReaderConfigResponseHeader     = 1037 // type 13
-	KeepaliveHeader                   = 1086 // type 62
-	KeepaliveAckHeader                = 1096 // type 72
 	GetReaderCapabilityHeader         = 1025 // type 1
-	GetReaderCapabilityResponseHeader = 1035 // type 11
 	GetReaderConfigHeader             = 1026 // type 2
+	SetReaderConfigHeader             = 1027 // type 3
+	GetReaderCapabilityResponseHeader = 1035 // type 11
 	GetReaderConfigResponseHeader     = 1036 // type 12
+	SetReaderConfigResponseHeader     = 1037 // type 13
+	AddRospecHeader                   = 1044 // type 20
+	DeleteRospecHeader                = 1045 // type 21
+	EnableRospecHeader                = 1048 // type 24
+	AddRospecResponseHeader           = 1054 // type 30
+	DeleteRospecResponseHeader        = 1055 // type 31
+	EnableRospecResponseHeader        = 1058 // type 34
 	DeleteAccessSpecHeader            = 1065 // type 41
 	DeleteAccessSpecResponseHeader    = 1075 // type 51
-	DeleteRospecHeader                = 1045 // type 21
-	DeleteRospecResponseHeader        = 1055 // type 31
-	AddRospecHeader                   = 1044 // type 20
-	AddRospecResponseHeader           = 1054 // type 30
-	EnableRospecHeader                = 1048 // type 24
-	EnableRospecResponseHeader        = 1058 // type 34
+	ROAccessReportHeader              = 1085 // type 61
+	KeepaliveHeader                   = 1086 // type 62
+	ReaderEventNotificationHeader     = 1087 // type 63
+	EventsAndReportsHeader            = 1088 // type 64
+	KeepaliveAckHeader                = 1096 // type 72
 	ImpinjEnableCutomMessageHeader    = 2047 // type 1023
 )
 

--- a/parameter.go
+++ b/parameter.go
@@ -47,7 +47,7 @@ func EPCData(length uint16, epcLengthBits uint16, epc []byte) []byte {
 			uint16(241),           // uint8(0)+uint8(Type=241)
 			uint16(length),        // Length
 			uint16(epcLengthBits), // EPCLengthBits
-			epc, // EPCData string
+			epc,                   // EPCData string
 		}
 	}
 	return Pack(data)
@@ -72,7 +72,7 @@ func LastSeenTimestampUTC() []byte {
 }
 
 func makeTimestamp() int64 {
-	return time.Now().UnixNano() / (int64(time.Millisecond) / int64(time.Nanosecond))
+	return time.Now().UnixNano() / (int64(time.Microsecond) / int64(time.Nanosecond))
 }
 
 //TagSeenCount :
@@ -122,7 +122,7 @@ func ReaderEventNotificationData(currentTime uint64) []byte {
 	readerEventNotificationDataLength := len(utcTimeStamp) +
 		len(connectionAttemptEvent) + 4 // Rsvd+Type+length=32bits=4bytes
 	var data = []interface{}{
-		uint16(246),                               // Rsvd+Type=246 (ReaderEventNotificationData parameter)
+		uint16(246), // Rsvd+Type=246 (ReaderEventNotificationData parameter)
 		uint16(readerEventNotificationDataLength), // Length
 		utcTimeStamp,
 		connectionAttemptEvent,


### PR DESCRIPTION
I think in the LLRP standard, timestamps are always in microsecond using long integers. At least that what iIve seen using Impinj Readers